### PR TITLE
Fixed unhandledRejectionError when fs.stat fails

### DIFF
--- a/packages/package-json/lib/package-json.js
+++ b/packages/package-json/lib/package-json.js
@@ -137,7 +137,8 @@ async function readPackages(packagePath) {
             return fs.stat(join(packagePath, packageName))
                 .then(function (stat) {
                     return stat.isDirectory();
-                });
+                })
+                .catch(() => false);
         })
         .map(function readPackageJson(packageName) {
             const absolutePath = join(packagePath, packageName);


### PR DESCRIPTION
no issue

An example where this can fail is when trying to read a broken symlink. If the path isn't able to be read, it is not a package
