### PR TITLE
Added transaction support to limit-service

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "eslint": "8.15.0",
-    "eslint-plugin-ghost": "2.13.0",
+    "eslint-plugin-ghost": "2.14.0",
     "mocha": "10.0.0",
     "should": "13.2.3",
     "sinon": "14.0.0"

--- a/packages/limit-service/.eslintrc.js
+++ b/packages/limit-service/.eslintrc.js
@@ -1,8 +1,5 @@
 module.exports = {
     plugins: ['ghost'],
-    parserOptions: {
-        ecmaVersion: 2020
-    },
     extends: [
         'plugin:ghost/node'
     ]

--- a/packages/limit-service/.eslintrc.js
+++ b/packages/limit-service/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
     plugins: ['ghost'],
+    parserOptions: {
+        ecmaVersion: 2020
+    },
     extends: [
         'plugin:ghost/node'
     ]

--- a/packages/limit-service/README.md
+++ b/packages/limit-service/README.md
@@ -133,6 +133,22 @@ if (limitService.checkIfAnyOverLimit()) {
 }
 ```
 
+### Transactions
+
+Some limit types (`max` or `maxPeriodic`) need to fetch the current count from the database. Sometimes you need those checks to also run in a transaction. To fix that, you can pass the `transacting` option to all the available checks.
+
+```js
+db.transaction((transacting) => {
+    const options = {transacting};
+    
+    await limitService.errorIfWouldGoOverLimit('newsletters', options);
+    await limitService.errorIfIsOverLimit('newsletters', options);
+    const a = await limitService.checkIsOverLimit('newsletters', options);
+    const b = await limitService.checkWouldGoOverLimit('newsletters', options);
+    const c = await limitService.checkIfAnyOverLimit(options);
+});
+```
+
 ### Types of limits
 At the moment there are four different types of limits that limit service allows to define. These types are:
 1. `flag` - is an "on/off" switch for certain feature. Example usecase: "disable all emails". It's identified by a `disabled: true` property in the "limits" configuration.

--- a/packages/limit-service/README.md
+++ b/packages/limit-service/README.md
@@ -17,6 +17,7 @@ or
 Below is a sample code to wire up limit service and perform few common limit checks:
 
 ```js
+const knex = require('knex');
 const errors = require('@tryghost/errors');
 const LimitService = require('@tryghost/limit-service');
 
@@ -80,15 +81,17 @@ const subscription = {
 const helpLink = 'https://ghost.org/help/';
 
 // initialize knex db connection for the limit service to use when running query checks
-const db = knex({
-    client: 'mysql',
-    connection: {
-        user: 'root',
-        password: 'toor',
-        host: 'localhost',
-        database: 'ghost',
-    }
-});
+const db = {
+    knex: knex({
+        client: 'mysql',
+        connection: {
+            user: 'root',
+            password: 'toor',
+            host: 'localhost',
+            database: 'ghost',
+        }
+    });
+};
 
 // finish initializing the limits service
 limitService.loadLimits({limits, subscription, db, helpLink, errors});
@@ -140,7 +143,7 @@ Some limit types (`max` or `maxPeriodic`) need to fetch the current count from t
 ```js
 db.transaction((transacting) => {
     const options = {transacting};
-    
+
     await limitService.errorIfWouldGoOverLimit('newsletters', options);
     await limitService.errorIfIsOverLimit('newsletters', options);
     const a = await limitService.checkIsOverLimit('newsletters', options);

--- a/packages/limit-service/lib/config.js
+++ b/packages/limit-service/lib/config.js
@@ -4,14 +4,14 @@
 // 2. MaxLimit should contain a `currentCountQuery` function which would count the resources under limit
 module.exports = {
     members: {
-        currentCountQuery: async (db) => {
-            let result = await db.knex('members').count('id', {as: 'count'}).first();
+        currentCountQuery: async (knex) => {
+            let result = await knex('members').count('id', {as: 'count'}).first();
             return result.count;
         }
     },
     newsletters: {
-        currentCountQuery: async (db) => {
-            let result = await db.knex('newsletters')
+        currentCountQuery: async (knex) => {
+            let result = await knex('newsletters')
                 .count('id', {as: 'count'})
                 .where('status', '=', 'active')
                 .first();
@@ -20,8 +20,8 @@ module.exports = {
         }
     },
     emails: {
-        currentCountQuery: async (db, startDate) => {
-            let result = await db.knex('emails')
+        currentCountQuery: async (knex, startDate) => {
+            let result = await knex('emails')
                 .sum('email_count', {as: 'count'})
                 .where('created_at', '>=', startDate)
                 .first();
@@ -30,13 +30,13 @@ module.exports = {
         }
     },
     staff: {
-        currentCountQuery: async (db) => {
-            let result = await db.knex('users')
+        currentCountQuery: async (knex) => {
+            let result = await knex('users')
                 .select('users.id')
                 .leftJoin('roles_users', 'users.id', 'roles_users.user_id')
                 .leftJoin('roles', 'roles_users.role_id', 'roles.id')
                 .whereNot('roles.name', 'Contributor').andWhereNot('users.status', 'inactive').union([
-                    db.knex('invites')
+                    knex('invites')
                         .select('invites.id')
                         .leftJoin('roles', 'invites.role_id', 'roles.id')
                         .whereNot('roles.name', 'Contributor')
@@ -46,8 +46,8 @@ module.exports = {
         }
     },
     customIntegrations: {
-        currentCountQuery: async (db) => {
-            let result = await db.knex('integrations')
+        currentCountQuery: async (knex) => {
+            let result = await knex('integrations')
                 .count('id', {as: 'count'})
                 .whereNotIn('type', ['internal', 'builtin'])
                 .first();

--- a/packages/limit-service/lib/limit-service.js
+++ b/packages/limit-service/lib/limit-service.js
@@ -70,17 +70,17 @@ class LimitService {
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} [metadata] - limit parameters
-     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @param {Object} [options] - limit parameters
+     * @param {Object} [options.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
-    async checkIsOverLimit(limitName, metadata = {}) {
+    async checkIsOverLimit(limitName, options = {}) {
         if (!this.isLimited(limitName)) {
             return;
         }
 
         try {
-            await this.limits[limitName].errorIfIsOverLimit(metadata);
+            await this.limits[limitName].errorIfIsOverLimit(options);
             return false;
         } catch (error) {
             if (error instanceof this.errors.HostLimitError) {
@@ -94,17 +94,17 @@ class LimitService {
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} [metadata] - limit parameters
-     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @param {Object} [options] - limit parameters
+     * @param {Object} [options.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
-    async checkWouldGoOverLimit(limitName, metadata = {}) {
+    async checkWouldGoOverLimit(limitName, options = {}) {
         if (!this.isLimited(limitName)) {
             return;
         }
 
         try {
-            await this.limits[limitName].errorIfWouldGoOverLimit(metadata);
+            await this.limits[limitName].errorIfWouldGoOverLimit(options);
             return false;
         } catch (error) {
             if (error instanceof this.errors.HostLimitError) {
@@ -118,43 +118,43 @@ class LimitService {
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} [metadata] - limit parameters
-     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @param {Object} [options] - limit parameters
+     * @param {Object} [options.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
-    async errorIfIsOverLimit(limitName, metadata = {}) {
+    async errorIfIsOverLimit(limitName, options = {}) {
         if (!this.isLimited(limitName)) {
             return;
         }
 
-        await this.limits[limitName].errorIfIsOverLimit(metadata);
+        await this.limits[limitName].errorIfIsOverLimit(options);
     }
 
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} [metadata] - limit parameters
-     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @param {Object} [options] - limit parameters
+     * @param {Object} [options.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
-    async errorIfWouldGoOverLimit(limitName, metadata = {}) {
+    async errorIfWouldGoOverLimit(limitName, options = {}) {
         if (!this.isLimited(limitName)) {
             return;
         }
 
-        await this.limits[limitName].errorIfWouldGoOverLimit(metadata);
+        await this.limits[limitName].errorIfWouldGoOverLimit(options);
     }
 
     /**
      * Checks if any of the configured limits acceded
      * 
-     * @param {Object} [metadata] - limit parameters
-     * @param {Object} [metadata.transacting] Transaction to run the count queries on (if required for the chosen limit)
+     * @param {Object} [options] - limit parameters
+     * @param {Object} [options.transacting] Transaction to run the count queries on (if required for the chosen limit)
      * @returns {Promise<boolean>}
      */
-    async checkIfAnyOverLimit(metadata = {}) {
+    async checkIfAnyOverLimit(options = {}) {
         for (const limit in this.limits) {
-            if (await this.checkIsOverLimit(limit, metadata)) {
+            if (await this.checkIsOverLimit(limit, options)) {
                 return true;
             }
         }

--- a/packages/limit-service/lib/limit-service.js
+++ b/packages/limit-service/lib/limit-service.js
@@ -67,13 +67,20 @@ class LimitService {
         return !!this.limits[_.camelCase(limitName)];
     }
 
-    async checkIsOverLimit(limitName) {
+    /**
+     *
+     * @param {String} limitName - name of the configured limit
+     * @param {Object} [metadata] - limit parameters
+     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @returns
+     */
+    async checkIsOverLimit(limitName, metadata = {}) {
         if (!this.isLimited(limitName)) {
             return;
         }
 
         try {
-            await this.limits[limitName].errorIfIsOverLimit();
+            await this.limits[limitName].errorIfIsOverLimit(metadata);
             return false;
         } catch (error) {
             if (error instanceof this.errors.HostLimitError) {
@@ -84,6 +91,13 @@ class LimitService {
         }
     }
 
+    /**
+     *
+     * @param {String} limitName - name of the configured limit
+     * @param {Object} [metadata] - limit parameters
+     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
+     * @returns
+     */
     async checkWouldGoOverLimit(limitName, metadata = {}) {
         if (!this.isLimited(limitName)) {
             return;
@@ -104,7 +118,8 @@ class LimitService {
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} metadata - limit parameters
+     * @param {Object} [metadata] - limit parameters
+     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
     async errorIfIsOverLimit(limitName, metadata = {}) {
@@ -118,7 +133,8 @@ class LimitService {
     /**
      *
      * @param {String} limitName - name of the configured limit
-     * @param {Object} metadata - limit parameters
+     * @param {Object} [metadata] - limit parameters
+     * @param {Object} [metadata.transacting] Transaction to run the count query on (if required for the chosen limit)
      * @returns
      */
     async errorIfWouldGoOverLimit(limitName, metadata = {}) {
@@ -131,12 +147,14 @@ class LimitService {
 
     /**
      * Checks if any of the configured limits acceded
-     *
+     * 
+     * @param {Object} [metadata] - limit parameters
+     * @param {Object} [metadata.transacting] Transaction to run the count queries on (if required for the chosen limit)
      * @returns {Promise<boolean>}
      */
-    async checkIfAnyOverLimit() {
+    async checkIfAnyOverLimit(metadata = {}) {
         for (const limit in this.limits) {
-            if (await this.checkIsOverLimit(limit)) {
+            if (await this.checkIsOverLimit(limit, metadata)) {
                 return true;
             }
         }

--- a/packages/limit-service/lib/limit.js
+++ b/packages/limit-service/lib/limit.js
@@ -104,7 +104,7 @@ class MaxLimit extends Limit {
      * @returns 
      */
     async currentCountQuery(options = {}) {
-        return await this.currentCountQueryFn(options.transacting ? options.transacting : (this.db ? this.db.knex : undefined));
+        return await this.currentCountQueryFn(options.transacting ?? this.db?.knex);
     }
 
     /**

--- a/packages/limit-service/lib/limit.js
+++ b/packages/limit-service/lib/limit.js
@@ -98,8 +98,13 @@ class MaxLimit extends Limit {
         return new this.errors.HostLimitError(errorObj);
     }
 
-    async currentCountQuery() {
-        return await this.currentCountQueryFn(this.db);
+    /**
+     * @param {Object} [options]
+     * @param {Object} [options.transacting] Transaction to run the count query on
+     * @returns 
+     */
+    async currentCountQuery(options = {}) {
+        return await this.currentCountQueryFn(options.transacting ? options.transacting : (this.db ? this.db.knex : undefined));
     }
 
     /**
@@ -108,9 +113,11 @@ class MaxLimit extends Limit {
      * @param {Object} options
      * @param {Number} [options.max] - overrides configured default max value to perform checks against
      * @param {Number} [options.addedCount] - number of items to add to the currentCount during the check
+     * @param {Object} [options.transacting] Transaction to run the count query on
      */
-    async errorIfWouldGoOverLimit({max, addedCount = 1} = {}) {
-        let currentCount = await this.currentCountQuery();
+    async errorIfWouldGoOverLimit(options = {}) {
+        const {max, addedCount = 1} = options;
+        let currentCount = await this.currentCountQuery(options);
 
         if ((currentCount + addedCount) > (max || this.max)) {
             throw this.generateError(currentCount);
@@ -123,11 +130,12 @@ class MaxLimit extends Limit {
      * @param {Object} options
      * @param {Number} [options.max] - overrides configured default max value to perform checks against
      * @param {Number} [options.currentCount] - overrides currentCountQuery to perform checks against
+     * @param {Object} [options.transacting] Transaction to run the count query on
      */
-    async errorIfIsOverLimit({max, currentCount} = {}) {
-        currentCount = currentCount || await this.currentCountQuery();
+    async errorIfIsOverLimit(options = {}) {
+        const currentCount = options.currentCount || await this.currentCountQuery(options);
 
-        if (currentCount > (max || this.max)) {
+        if (currentCount > (options.max || this.max)) {
             throw this.generateError(currentCount);
         }
     }
@@ -202,10 +210,15 @@ class MaxPeriodicLimit extends Limit {
         return new this.errors.HostLimitError(errorObj);
     }
 
-    async currentCountQuery() {
+    /**
+     * @param {Object} [options]
+     * @param {Object} [options.transacting] Transaction to run the count query on
+     * @returns 
+     */
+    async currentCountQuery(options = {}) {
         const lastPeriodStartDate = lastPeriodStart(this.startDate, this.interval);
 
-        return await this.currentCountQueryFn(this.db, lastPeriodStartDate);
+        return await this.currentCountQueryFn(options.transacting ? options.transacting : (this.db ? this.db.knex : undefined), lastPeriodStartDate);
     }
 
     /**
@@ -214,9 +227,11 @@ class MaxPeriodicLimit extends Limit {
      * @param {Object} options
      * @param {Number} [options.max] - overrides configured default maxPeriodic value to perform checks against
      * @param {Number} [options.addedCount] - number of items to add to the currentCount during the check
+     * @param {Object} [options.transacting] Transaction to run the count query on
      */
-    async errorIfWouldGoOverLimit({max, addedCount = 1} = {}) {
-        let currentCount = await this.currentCountQuery();
+    async errorIfWouldGoOverLimit(options = {}) {
+        const {max, addedCount = 1} = options;
+        let currentCount = await this.currentCountQuery(options);
 
         if ((currentCount + addedCount) > (max || this.maxPeriodic)) {
             throw this.generateError(currentCount);
@@ -228,9 +243,11 @@ class MaxPeriodicLimit extends Limit {
      *
      * @param {Object} options
      * @param {Number} [options.max] - overrides configured default maxPeriodic value to perform checks against
+     * @param {Object} [options.transacting] Transaction to run the count query on
      */
-    async errorIfIsOverLimit({max} = {}) {
-        let currentCount = await this.currentCountQuery();
+    async errorIfIsOverLimit(options = {}) {
+        const {max} = options;
+        let currentCount = await this.currentCountQuery(options);
 
         if (currentCount > (max || this.maxPeriodic)) {
             throw this.generateError(currentCount);

--- a/packages/limit-service/test/limit-service.test.js
+++ b/packages/limit-service/test/limit-service.test.js
@@ -347,7 +347,7 @@ describe('Limit Service', function () {
             sinon.restore();
         });
 
-        it('passes metadata for checkIsOverLimit', async function () {
+        it('passes options for checkIsOverLimit', async function () {
             const limitService = new LimitService();
 
             let limits = {
@@ -366,17 +366,17 @@ describe('Limit Service', function () {
 
             limitService.loadLimits({limits, errors, subscription});
 
-            const metadata = {
+            const options = {
                 testData: 'true'
             };
 
-            await limitService.checkIsOverLimit('staff', metadata);
+            await limitService.checkIsOverLimit('staff', options);
 
             sinon.assert.callCount(maxSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, options);
         });
 
-        it('passes metadata for checkWouldGoOverLimit', async function () {
+        it('passes options for checkWouldGoOverLimit', async function () {
             const limitService = new LimitService();
 
             let limits = {
@@ -395,17 +395,17 @@ describe('Limit Service', function () {
 
             limitService.loadLimits({limits, errors, subscription});
 
-            const metadata = {
+            const options = {
                 testData: 'true'
             };
 
-            await limitService.checkWouldGoOverLimit('staff', metadata);
+            await limitService.checkWouldGoOverLimit('staff', options);
 
             sinon.assert.callCount(maxSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, options);
         });
 
-        it('passes metadata for errorIfIsOverLimit', async function () {
+        it('passes options for errorIfIsOverLimit', async function () {
             const limitService = new LimitService();
 
             let limits = {
@@ -424,17 +424,17 @@ describe('Limit Service', function () {
 
             limitService.loadLimits({limits, errors, subscription});
 
-            const metadata = {
+            const options = {
                 testData: 'true'
             };
 
-            await limitService.errorIfIsOverLimit('staff', metadata);
+            await limitService.errorIfIsOverLimit('staff', options);
 
             sinon.assert.callCount(maxSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, options);
         });
 
-        it('passes metadata for errorIfWouldGoOverLimit', async function () {
+        it('passes options for errorIfWouldGoOverLimit', async function () {
             const limitService = new LimitService();
 
             let limits = {
@@ -453,17 +453,17 @@ describe('Limit Service', function () {
 
             limitService.loadLimits({limits, errors, subscription});
 
-            const metadata = {
+            const options = {
                 testData: 'true'
             };
 
-            await limitService.errorIfWouldGoOverLimit('staff', metadata);
+            await limitService.errorIfWouldGoOverLimit('staff', options);
 
             sinon.assert.callCount(maxSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, options);
         });
 
-        it('passes metadata for checkIfAnyOverLimit', async function () {
+        it('passes options for checkIfAnyOverLimit', async function () {
             const limitService = new LimitService();
 
             let limits = {
@@ -495,20 +495,20 @@ describe('Limit Service', function () {
 
             limitService.loadLimits({limits, errors, subscription});
 
-            const metadata = {
+            const options = {
                 testData: 'true'
             };
 
-            (await limitService.checkIfAnyOverLimit(metadata)).should.be.false();
+            (await limitService.checkIfAnyOverLimit(options)).should.be.false();
 
             sinon.assert.callCount(flagSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(flagSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(flagSpy, options);
 
             sinon.assert.callCount(maxSpy, 2);
-            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, options);
 
             sinon.assert.callCount(maxPeriodSpy, 1);
-            sinon.assert.alwaysCalledWithExactly(maxPeriodSpy, metadata);
+            sinon.assert.alwaysCalledWithExactly(maxPeriodSpy, options);
         });
     });
 });

--- a/packages/limit-service/test/limit-service.test.js
+++ b/packages/limit-service/test/limit-service.test.js
@@ -4,6 +4,7 @@ require('./utils');
 const should = require('should');
 const LimitService = require('../lib/limit-service');
 const {MaxLimit, MaxPeriodicLimit, FlagLimit} = require('../lib/limit');
+const sinon = require('sinon');
 
 const errors = require('./fixtures/errors');
 
@@ -338,6 +339,176 @@ describe('Limit Service', function () {
             } catch (err) {
                 err.message.should.eql(`Attempted to check an allowlist limit without a value`);
             }
+        });
+    });
+
+    describe('Metadata', function () {
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('passes metadata for checkIsOverLimit', async function () {
+            const limitService = new LimitService();
+
+            let limits = {
+                staff: {
+                    max: 2,
+                    currentCountQuery: () => 1
+                }
+            };
+
+            const maxSpy = sinon.spy(MaxLimit.prototype, 'errorIfIsOverLimit');
+
+            const subscription = {
+                interval: 'month',
+                startDate: '2021-09-18T19:00:52Z'
+            };
+
+            limitService.loadLimits({limits, errors, subscription});
+
+            const metadata = {
+                testData: 'true'
+            };
+
+            await limitService.checkIsOverLimit('staff', metadata);
+
+            sinon.assert.callCount(maxSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+        });
+
+        it('passes metadata for checkWouldGoOverLimit', async function () {
+            const limitService = new LimitService();
+
+            let limits = {
+                staff: {
+                    max: 2,
+                    currentCountQuery: () => 1
+                }
+            };
+
+            const maxSpy = sinon.spy(MaxLimit.prototype, 'errorIfWouldGoOverLimit');
+
+            const subscription = {
+                interval: 'month',
+                startDate: '2021-09-18T19:00:52Z'
+            };
+
+            limitService.loadLimits({limits, errors, subscription});
+
+            const metadata = {
+                testData: 'true'
+            };
+
+            await limitService.checkWouldGoOverLimit('staff', metadata);
+
+            sinon.assert.callCount(maxSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+        });
+
+        it('passes metadata for errorIfIsOverLimit', async function () {
+            const limitService = new LimitService();
+
+            let limits = {
+                staff: {
+                    max: 2,
+                    currentCountQuery: () => 1
+                }
+            };
+
+            const maxSpy = sinon.spy(MaxLimit.prototype, 'errorIfIsOverLimit');
+
+            const subscription = {
+                interval: 'month',
+                startDate: '2021-09-18T19:00:52Z'
+            };
+
+            limitService.loadLimits({limits, errors, subscription});
+
+            const metadata = {
+                testData: 'true'
+            };
+
+            await limitService.errorIfIsOverLimit('staff', metadata);
+
+            sinon.assert.callCount(maxSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+        });
+
+        it('passes metadata for errorIfWouldGoOverLimit', async function () {
+            const limitService = new LimitService();
+
+            let limits = {
+                staff: {
+                    max: 2,
+                    currentCountQuery: () => 1
+                }
+            };
+
+            const maxSpy = sinon.spy(MaxLimit.prototype, 'errorIfWouldGoOverLimit');
+
+            const subscription = {
+                interval: 'month',
+                startDate: '2021-09-18T19:00:52Z'
+            };
+
+            limitService.loadLimits({limits, errors, subscription});
+
+            const metadata = {
+                testData: 'true'
+            };
+
+            await limitService.errorIfWouldGoOverLimit('staff', metadata);
+
+            sinon.assert.callCount(maxSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+        });
+
+        it('passes metadata for checkIfAnyOverLimit', async function () {
+            const limitService = new LimitService();
+
+            let limits = {
+                staff: {
+                    max: 2,
+                    currentCountQuery: () => 2
+                },
+                members: {
+                    max: 100,
+                    currentCountQuery: () => 100
+                },
+                emails: {
+                    maxPeriodic: 3,
+                    currentCountQuery: () => 3
+                },
+                customIntegrations: {
+                    disabled: true
+                }
+            };
+
+            const flagSpy = sinon.spy(FlagLimit.prototype, 'errorIfIsOverLimit');
+            const maxSpy = sinon.spy(MaxLimit.prototype, 'errorIfIsOverLimit');
+            const maxPeriodSpy = sinon.spy(MaxPeriodicLimit.prototype, 'errorIfIsOverLimit');
+
+            const subscription = {
+                interval: 'month',
+                startDate: '2021-09-18T19:00:52Z'
+            };
+
+            limitService.loadLimits({limits, errors, subscription});
+
+            const metadata = {
+                testData: 'true'
+            };
+
+            (await limitService.checkIfAnyOverLimit(metadata)).should.be.false();
+
+            sinon.assert.callCount(flagSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(flagSpy, metadata);
+
+            sinon.assert.callCount(maxSpy, 2);
+            sinon.assert.alwaysCalledWithExactly(maxSpy, metadata);
+
+            sinon.assert.callCount(maxPeriodSpy, 1);
+            sinon.assert.alwaysCalledWithExactly(maxPeriodSpy, metadata);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,10 +1173,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-plugin-ember@10.5.9:
-  version "10.5.9"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-10.5.9.tgz#4071ac135c7207c7d4942e9fa75b710214885469"
-  integrity sha512-kJsdAaKNcfRvZBZ+YZ67pxxUgl+aPLFAnoFJNwTo+BsaptiOCsHUEc4xUKXiInH2BJOC6mg0FQcZKn1a6gwKrA==
+eslint-plugin-ember@10.6.1:
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-10.6.1.tgz#04ea84cc82307f64a2faa4f2855b30e5ebf9f722"
+  integrity sha512-R+TN3jwhYQ2ytZCA1VkfJDZSGgHFOHjsHU1DrBlRXYRepThe56PpuGxywAyDvQ7inhoAz3e6G6M60PzpvjzmNg==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
     css-tree "^2.0.4"
@@ -1205,18 +1205,18 @@ eslint-plugin-filenames@1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-ghost@2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ghost/-/eslint-plugin-ghost-2.13.0.tgz#1ab0ec7d508b38e33c39e8d4d22ef21632b488cb"
-  integrity sha512-l0r9NGeGOrjXQtgLdDZjdXuJjyNMOTES4DqzEob5FrQM80bnLjbbRBrBXDt637ZZW9+nPcsCv8x6bDHAf1Ds5w==
+eslint-plugin-ghost@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ghost/-/eslint-plugin-ghost-2.14.0.tgz#cabfa6910f5f2053954dbad5f6ea3a8828035c36"
+  integrity sha512-vccwznFPJvZdPZmgq9GyBkPtf6hrharOYf8jny4s6H28mTv65TB02lxY5GTLBqA5FvgSsXPYTPXxIFp+V5n/nw==
   dependencies:
     "@kapouer/eslint-plugin-no-return-in-loop" "1.0.0"
-    eslint-plugin-ember "10.5.9"
+    eslint-plugin-ember "10.6.1"
     eslint-plugin-filenames "1.3.2"
     eslint-plugin-mocha "7.0.1"
     eslint-plugin-node "11.1.0"
     eslint-plugin-sort-imports-es6-autofix "0.6.0"
-    eslint-plugin-unicorn "41.0.0"
+    eslint-plugin-unicorn "42.0.0"
 
 eslint-plugin-mocha@7.0.1:
   version "7.0.1"
@@ -1243,10 +1243,10 @@ eslint-plugin-sort-imports-es6-autofix@0.6.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6-autofix/-/eslint-plugin-sort-imports-es6-autofix-0.6.0.tgz#b8cd8639d7a54cefce6b17898b102fd5ec31e52b"
   integrity sha512-2NVaBGF9NN+727Fyq+jJYihdIeegjXeUUrZED9Q8FVB8MsV3YQEyXG96GVnXqWt0pmn7xfCZOZf3uKnIhBrfeQ==
 
-eslint-plugin-unicorn@41.0.0:
-  version "41.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-41.0.0.tgz#bf0974f8551ab4dd4aaae7d9cf53894040defbbd"
-  integrity sha512-xoJCaRc1uy5REg9DkVga1BkZV57jJxoqOcrU28QHZB89Lk5LdSqdVyTIt9JQVfHNKaiyJ7X+3iLlIn+VEHWEzA==
+eslint-plugin-unicorn@42.0.0:
+  version "42.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz#47d60c00c263ad743403b052db689e39acbacff1"
+  integrity sha512-ixBsbhgWuxVaNlPTT8AyfJMlhyC5flCJFjyK3oKE8TRrwBnaHvUbuIkCM1lqg8ryYrFStL/T557zfKzX4GKSlg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
     ci-info "^3.3.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/14780
refs https://github.com/TryGhost/Team/issues/1583

- We need transaction support in the limit-service so that we can run the count queries in the same transaction
- This is required to avoid deadlocks when we check the limits when a transaction is in progress on the same tables
- This issue specifically is required for newsletters, where we start a transaction when creating a newsletter.

Normally, everything should work as expected. **Unless**, we override the `currentCountQuery` queries somewhere where they also use the passed db attribute. In the admin client, `currentCountQuery` is overridden, but this doesn't use the knex property (tested and it works fine). Do we have other places where this is changed?