### PR TITLE
Added support for converting image types, gifs and svgs

### DIFF
--- a/packages/image-transform/test/transform.test.js
+++ b/packages/image-transform/test/transform.test.js
@@ -23,27 +23,54 @@ describe('Transform', function () {
     });
 
     describe('canTransformFileExtension', function () {
-        it('returns false for ".gif"', function () {
+        it('returns true for ".gif"', function () {
             should.equal(
                 transform.canTransformFileExtension('.gif'),
-                false
+                true
             );
         });
-        it('returns false for ".svg"', function () {
+        it('returns true for ".svg"', function () {
             should.equal(
                 transform.canTransformFileExtension('.svg'),
-                false
+                true
             );
         });
-        it('returns false for ".svgz"', function () {
+        it('returns true for ".svgz"', function () {
             should.equal(
                 transform.canTransformFileExtension('.svgz'),
-                false
+                true
             );
         });
         it('returns false for ".ico"', function () {
             should.equal(
                 transform.canTransformFileExtension('.ico'),
+                false
+            );
+        });
+    });
+
+    describe('shouldResizeFileExtension', function () {
+        it('returns true for ".gif"', function () {
+            should.equal(
+                transform.shouldResizeFileExtension('.gif'),
+                true
+            );
+        });
+        it('returns false for ".svg"', function () {
+            should.equal(
+                transform.shouldResizeFileExtension('.svg'),
+                false
+            );
+        });
+        it('returns false for ".svgz"', function () {
+            should.equal(
+                transform.shouldResizeFileExtension('.svgz'),
+                false
+            );
+        });
+        it('returns false for ".ico"', function () {
+            should.equal(
+                transform.shouldResizeFileExtension('.ico'),
                 false
             );
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1652
refs https://github.com/TryGhost/Ghost/issues/13319

- Added support for animated webp and gifs optimization and resizing
- Added optinal `format` option to `unsafeResizeFromBuffer` and `resizeFromBuffer`. E.g. allows you to convert a .svg file to a .png.
- Added optional `animated` option  to `unsafeResizeFromBuffer` and `resizeFromBuffer`. Defaults to 'maintain animation'.
- Added optional `withoutEnlargement` option  to `unsafeResizeFromBuffer` and `resizeFromBuffer`. Defaults to true. Required to increase SVG size.
- Removed gif and svg from `canTransformFileExtension`. They are supported by sharp now.
- Added `shouldResizeFileExtension` method, which returns if we should resize an image. This is required to prevent resizing SVG files (while it is supported, it is not desired), while allowing them to be converted to PNG (thats why a new method was needed).
- Added `canTransformToFormat` to validate the `format` option.
- Improved TS/JSDoc type inheritance when `makeSafe` is used.